### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you don't already have Vcpkg installed somewhere, go ahead and install it und
 Now, from the workspace root folder, update your `PATH` environment variable so that PlyTool is able to locate `vcpkg.exe`. (If you have Vcpkg installed to a different path, specify that path instead. Make sure you've installed Assimp in that instance of Vcpkg, too.)
 
     (from the workspace root)
-    > set PATH="%CD%\data\vcpkg";%PATH%
+    > set "PATH=%CD%\data\vcpkg;%PATH%"
 
 Finally, tell PlyTool that the current build folder should use the `assimp.vcpkg` provider:
 


### PR DESCRIPTION
Fix setting path on Windows, quote entire expression, not just to the new addition. Both work to update the path, but `where` command fails with the original suggestion, thus vcpkg can not be located.